### PR TITLE
add custodian to meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - pybtex >=0.24,<1.dev0
     - typing-extensions >=3.7
     - spglib >=2.0.1
+    - custodian >=2023.10.9
 
 test:
   imports:


### PR DESCRIPTION
Over in `pyiron_atomistics`, we got CI run fails due to the `emmet-core` package seemingly not stating its dependence on `custodian`, have a look at e.g. [this PR](https://github.com/pyiron/pyiron_atomistics/pull/1210), where we provide a hotfix for this by adding `custodian` to our dependencies. For a clean solution, however, `custodian`
should be added to `emmet-core`'s dependencies. I also [raised an issue](https://github.com/materialsproject/emmet/issues/890) on this in the `emmet-core` repository.